### PR TITLE
Add Folia alongside Bukkit, Spigot & Paper

### DIFF
--- a/src/routes/add-plugin/platform-select-step.svelte
+++ b/src/routes/add-plugin/platform-select-step.svelte
@@ -18,7 +18,7 @@
     export const platformOptions = [
         {
             id: 'bukkit',
-            label: 'Bukkit / Spigot / Paper',
+            label: 'Bukkit / Spigot / Paper / Folia',
             iconUrl: imgSpigot
         },
         {


### PR DESCRIPTION
Folia is becoming more well known, to avoid any confusion I added the following:
<img width="518" height="93" alt="image" src="https://github.com/user-attachments/assets/c3ac5513-4276-4956-8fbc-75aba7ff46e2" />

As it is a small change, I tested by just building and running the frontend.
